### PR TITLE
Bump Deployment Targets to iOS 13, macOS 11, tvOS 13. Fixes #2

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   create_release:
     name: Create Release
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/jazzy-docs.yml
+++ b/.github/workflows/jazzy-docs.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   deploy_docs:
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-12
 
     steps:
       - uses: actions/checkout@v2

--- a/Package.swift
+++ b/Package.swift
@@ -1,13 +1,13 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.6
 
 import PackageDescription
 
 let package = Package(
     name: "Decomposed",
     platforms: [
-      .iOS(.v10),
-      .macOS(.v10_12),
-      .tvOS(.v10)
+      .iOS(.v13),
+      .macOS(.v11),
+      .tvOS(.v13)
     ],
     products: [
         .library(


### PR DESCRIPTION
This drops support for iOS 12 and below, macOS 10.12 and below, and tvOS 13 and below.

If needed, version 0.2.0 can be used to support those versions.